### PR TITLE
attach .errors from levelup to Level constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![npm](https://img.shields.io/npm/dm/level-packager.svg)](https://www.npmjs.com/package/level-packager)
 
+## API
+
 Exports a single function which takes a single argument, an `abstract-leveldown` compatible storage back-end for [`levelup`](https://github.com/Level/levelup). The function returns a constructor function that will bundle `levelup` with the given `abstract-leveldown` replacement. The full API is supported, including optional functions, `destroy()`, and `repair()`. Encoding functionality is provided by [`encoding-down`](https://github.com/Level/encoding-down).
+
+The constructor function has a `.errors` property which provides access to the different error types from [`level-errors`](https://github.com/Level/errors#api).
 
 For example use-cases, see:
 
@@ -22,8 +26,7 @@ For example use-cases, see:
 Also available is a *test.js* file that can be used to verify that the user-package works as expected.
 
 <a name="contributing"></a>
-Contributing
-------------
+## Contributing
 
 `level-packager` is an **OPEN Open Source Project**. This means that:
 
@@ -32,8 +35,7 @@ Contributing
 See the [contribution guide](https://github.com/Level/community/blob/master/CONTRIBUTING.md) for more details.
 
 <a name="license"></a>
-License &amp; Copyright
--------------------
+## License &amp; Copyright
 
 Copyright (c) 2012-2017 `level-packager` [contributors](https://github.com/level/community#contributors).
 

--- a/level-packager.js
+++ b/level-packager.js
@@ -21,6 +21,8 @@ function packager (leveldown) {
     }
   })
 
+  Level.errors = levelup.errors
+
   return Level
 }
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,11 @@ const location = path.join(__dirname, 'level-test-' + process.pid + '.db')
 module.exports = function (test, level, options) {
   options = options || {}
 
+  test('Level constructor provides access to levelup errors', function (t) {
+    t.ok(level.errors, '.errors property set on constructor')
+    t.end()
+  })
+
   test('test db open and use, level(location, cb)', function (t) {
     level(location, function (err, db) {
       t.notOk(err, 'no error')


### PR DESCRIPTION
This simplifies access to level errors, so you can do:

```js
const level = require('level')                                
                                                              
level('./db', { createIfMissing: false }, function (err, db) {
  if (err instanceof level.errors.OpenError) {                
    console.log('open failed because expected db to exist')   
  }                                                           
})                                                            
```

It's also convenient to use in `level-packager` since it automatically gives access to `.errors` for all flavors.