### PR TITLE
Don't assume existence of a LOG file in abstract destroy-test

### DIFF
--- a/abstract/destroy-test.js
+++ b/abstract/destroy-test.js
@@ -8,10 +8,10 @@ module.exports = function (test, level) {
   test('test destroy', function (t) {
     t.plan(4)
     t.ok(fs.statSync(location).isDirectory(), 'sanity check, directory exists')
-    t.ok(fs.existsSync(path.join(location, 'LOG')), 'sanity check, log exists')
+    t.ok(fs.existsSync(path.join(location, 'CURRENT')), 'sanity check, CURRENT exists')
     level.destroy(location, function (err) {
       t.notOk(err, 'no error')
-      t.notOk(fs.existsSync(path.join(location, 'LOG')), 'db gone (mostly)')
+      t.notOk(fs.existsSync(path.join(location, 'CURRENT')), 'db gone (mostly)')
     })
   })
 }


### PR DESCRIPTION
This is needed for `level-rocksdb` because starting with `rocksdb@4` it doesn't create a `LOG` file (https://github.com/Level/rocksdb/pull/114).

The `CURRENT` file however, should always exist, at least in `leveldown` and `rocksdb` to my knowledge.