### PR TITLE
fix: pass options to level

### DIFF
--- a/level-packager.js
+++ b/level-packager.js
@@ -13,7 +13,7 @@ function packager (leveldown) {
       options = isObject(location) ? location : {}
     }
 
-    return levelup(encode(leveldown(location), options), options, callback)
+    return levelup(encode(leveldown(location, options), options), options, callback)
   }
 
   function isObject (o) {

--- a/test.js
+++ b/test.js
@@ -73,6 +73,22 @@ test('Level constructor with location', function (t) {
   t.is(levelup.options.valueEncoding, 'utf8')
 })
 
+test('Level constructor with location & options', function (t) {
+  t.plan(2)
+  function Down (location, opts) {
+    t.is(location, 'location', 'location is correct')
+    t.same(opts, {
+      prefix: 'foo'
+    })
+    return {
+      open: function (opts, cb) {
+        cb()
+      }
+    }
+  }
+  packager(Down)('location', { prefix: 'foo' })
+})
+
 test('Level constructor with callback', function (t) {
   t.plan(3)
   function Down () {
@@ -116,7 +132,7 @@ test('Level constructor with location & callback', function (t) {
   })
 })
 
-test('Level constructor with location & options', function (t) {
+test('Level constructor with location & options passed to levelup', function (t) {
   t.plan(4)
   var Down = function (location) {
     t.is(location, 'location', 'location is correct')
@@ -139,7 +155,7 @@ test('Level constructor with location & options', function (t) {
   t.is(levelup.options.valueEncoding, 'binary')
 })
 
-test('Level constructor with options', function (t) {
+test('Level constructor with options passed to levelup', function (t) {
   t.plan(3)
   var Down = function () {
     return {
@@ -161,7 +177,7 @@ test('Level constructor with options', function (t) {
   t.is(levelup.options.valueEncoding, 'binary')
 })
 
-test('Level constructor with options & callback', function (t) {
+test('Level constructor with options & callback passed to levelup', function (t) {
   t.plan(5)
   var Down = function () {
     return {


### PR DESCRIPTION
I'm trying to use the `prefix` option of `level-js` to override [`this.prefix`](https://github.com/Level/level-js/blob/master/index.js#L36), but the `options` arg is not being passed to `level-js`.

This PR passes options to the specified `level` implementation and adds a test for the same.  It also renames a couple of the tests to be more specific as they test the options were passed to the `levelup` wrapper, rather than the underlying `level` implementation, which is what the added test tests.